### PR TITLE
Write out additional emulation pattern files

### DIFF
--- a/L1Trigger/DemonstratorTools/interface/codecs/vertices.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/vertices.h
@@ -2,16 +2,25 @@
 #ifndef L1Trigger_DemonstratorTools_codecs_vertices_h
 #define L1Trigger_DemonstratorTools_codecs_vertices_h
 
+#include <array>
 #include <vector>
 
-#include "DataFormats/L1Trigger/interface/VertexWord.h"
+#include "ap_int.h"
 
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/L1Trigger/interface/Vertex.h"
+#include "DataFormats/L1Trigger/interface/VertexWord.h"
 #include "L1Trigger/DemonstratorTools/interface/BoardData.h"
 
 namespace l1t::demo::codecs {
 
+  ap_uint<64> encodeVertex(const l1t::VertexWord& v);
+
+  // Encodes vertex collection onto 1 'logical' output link
+  std::array<l1t::demo::BoardData::Channel, 1> encodeVertices(const edm::View<l1t::VertexWord>&);
+
   std::vector<l1t::VertexWord> decodeVertices(const l1t::demo::BoardData::Channel&);
 
-}
+}  // namespace l1t::demo::codecs
 
 #endif

--- a/L1Trigger/DemonstratorTools/plugins/GTTFileReader.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileReader.cc
@@ -48,35 +48,26 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
+  // ----------constants, enums and typedefs ---------
+  // NOTE: At least some of the info from these constants will eventually come from config files
+  static constexpr size_t kFramesPerTMUXPeriod = 9;
+  static constexpr size_t kGapLength = 44;
+  static constexpr size_t kVertexTMUX = 6;
+  static constexpr size_t kVertexChanIndex = 0;
+  static constexpr size_t kEmptyFrames = 10;
+
+  const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecs = {
+      /* channel index -> {link TMUX, TMUX index, inter-packet gap} */
+      {kVertexChanIndex, {kVertexTMUX, 0, kGapLength}}};
+
+  // ----------member functions ----------------------
   void beginStream(edm::StreamID) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
   void endStream() override;
 
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-
   // ----------member data ---------------------------
   l1t::demo::BoardDataReader fileReader_;
 };
-
-//
-// constants, enums and typedefs
-//
-
-// NOTE: At least some of the info from these constants will eventually come from config files
-constexpr size_t kGapLength(44);
-constexpr size_t kVertexTMUX(6);
-constexpr size_t kVertexChanIndex(0);
-
-const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecs = {
-    /* channel index -> {link TMUX, TMUX index, inter-packet gap} */
-    {kVertexChanIndex, {kVertexTMUX, 0, kGapLength}}};
-
-//
-// static data member definitions
-//
 
 //
 // constructors and destructor
@@ -85,9 +76,9 @@ const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecs = {
 GTTFileReader::GTTFileReader(const edm::ParameterSet& iConfig)
     : fileReader_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
                   iConfig.getParameter<std::vector<std::string>>("files"),
-                  9,
-                  6,
-                  10,
+                  kFramesPerTMUXPeriod,
+                  kVertexTMUX,
+                  kEmptyFrames,
                   kChannelSpecs) {
   produces<l1t::VertexWordCollection>();
 }
@@ -130,38 +121,6 @@ void GTTFileReader::beginStream(edm::StreamID) {
 void GTTFileReader::endStream() {
   // please remove this method if not needed
 }
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void
-GTTFileReader::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void
-GTTFileReader::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void
-GTTFileReader::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void
-GTTFileReader::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void GTTFileReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/DemonstratorTools/plugins/GTTFileReader.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileReader.cc
@@ -1,9 +1,9 @@
 // -*- C++ -*-
 //
 // Package:    L1Trigger/DemonstratorTools
-// Class:      GTTOutputFileReader
+// Class:      GTTFileReader
 //
-/**\class GTTOutputFileReader GTTOutputFileReader.cc L1Trigger/DemonstratorTools/plugins/GTTOutputFileReader.cc
+/**\class GTTFileReader GTTFileReader.cc L1Trigger/DemonstratorTools/plugins/GTTFileReader.cc
 
  Description: Example EDProducer class, illustrating how BoardDataReader can be used to
    read I/O buffer files (that have been created in hardware/firmware tests), decode
@@ -40,10 +40,10 @@
 // class declaration
 //
 
-class GTTOutputFileReader : public edm::stream::EDProducer<> {
+class GTTFileReader : public edm::stream::EDProducer<> {
 public:
-  explicit GTTOutputFileReader(const edm::ParameterSet&);
-  ~GTTOutputFileReader() override;
+  explicit GTTFileReader(const edm::ParameterSet&);
+  ~GTTFileReader() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -82,7 +82,7 @@ const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecs = {
 // constructors and destructor
 //
 
-GTTOutputFileReader::GTTOutputFileReader(const edm::ParameterSet& iConfig)
+GTTFileReader::GTTFileReader(const edm::ParameterSet& iConfig)
     : fileReader_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
                   iConfig.getParameter<std::vector<std::string>>("files"),
                   9,
@@ -92,7 +92,7 @@ GTTOutputFileReader::GTTOutputFileReader(const edm::ParameterSet& iConfig)
   produces<l1t::VertexWordCollection>();
 }
 
-GTTOutputFileReader::~GTTOutputFileReader() {
+GTTFileReader::~GTTFileReader() {
   // do anything here that needs to be done at destruction time
   // (e.g. close files, deallocate resources etc.)
   //
@@ -104,7 +104,7 @@ GTTOutputFileReader::~GTTOutputFileReader() {
 //
 
 // ------------ method called to produce the data  ------------
-void GTTOutputFileReader::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void GTTFileReader::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
   l1t::demo::BoardData eventData(fileReader_.getNextEvent());
@@ -122,19 +122,19 @@ void GTTOutputFileReader::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 }
 
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void GTTOutputFileReader::beginStream(edm::StreamID) {
+void GTTFileReader::beginStream(edm::StreamID) {
   // please remove this method if not needed
 }
 
 // ------------ method called once each stream after processing all runs, lumis and events  ------------
-void GTTOutputFileReader::endStream() {
+void GTTFileReader::endStream() {
   // please remove this method if not needed
 }
 
 // ------------ method called when starting to processes a run  ------------
 /*
 void
-GTTOutputFileReader::beginRun(edm::Run const&, edm::EventSetup const&)
+GTTFileReader::beginRun(edm::Run const&, edm::EventSetup const&)
 {
 }
 */
@@ -142,7 +142,7 @@ GTTOutputFileReader::beginRun(edm::Run const&, edm::EventSetup const&)
 // ------------ method called when ending the processing of a run  ------------
 /*
 void
-GTTOutputFileReader::endRun(edm::Run const&, edm::EventSetup const&)
+GTTFileReader::endRun(edm::Run const&, edm::EventSetup const&)
 {
 }
 */
@@ -150,7 +150,7 @@ GTTOutputFileReader::endRun(edm::Run const&, edm::EventSetup const&)
 // ------------ method called when starting to processes a luminosity block  ------------
 /*
 void
-GTTOutputFileReader::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+GTTFileReader::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
 {
 }
 */
@@ -158,13 +158,13 @@ GTTOutputFileReader::beginLuminosityBlock(edm::LuminosityBlock const&, edm::Even
 // ------------ method called when ending the processing of a luminosity block  ------------
 /*
 void
-GTTOutputFileReader::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+GTTFileReader::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
 {
 }
 */
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void GTTOutputFileReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void GTTFileReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
@@ -173,4 +173,4 @@ void GTTOutputFileReader::fillDescriptions(edm::ConfigurationDescriptions& descr
 }
 
 //define this as a plug-in
-DEFINE_FWK_MODULE(GTTOutputFileReader);
+DEFINE_FWK_MODULE(GTTFileReader);

--- a/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
@@ -1,9 +1,9 @@
 // -*- C++ -*-
 //
 // Package:    L1Trigger/DemonstratorTools
-// Class:      GTTInputFileWriter
+// Class:      GTTFileWriter
 //
-/**\class GTTInputFileWriter GTTInputFileWriter.cc L1Trigger/DemonstratorTools/plugins/GTTInputFileWriter.cc
+/**\class GTTFileWriter GTTFileWriter.cc L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
 
  Description: Example EDAnalyzer class, illustrating how BoardDataWriter can be used to write I/O buffer files for hardware/firmware tests
 
@@ -47,10 +47,10 @@
 // from  edm::one::EDAnalyzer<>
 // This will improve performance in multithreaded jobs.
 
-class GTTInputFileWriter : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+class GTTFileWriter : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
-  explicit GTTInputFileWriter(const edm::ParameterSet&);
-  ~GTTInputFileWriter() override;
+  explicit GTTFileWriter(const edm::ParameterSet&);
+  ~GTTFileWriter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -116,7 +116,7 @@ const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecsOutputToCorrelator =
 // constructors and destructor
 //
 
-GTTInputFileWriter::GTTInputFileWriter(const edm::ParameterSet& iConfig)
+GTTFileWriter::GTTFileWriter(const edm::ParameterSet& iConfig)
     : tracksToken_(consumes<edm::View<Track_t>>(iConfig.getUntrackedParameter<edm::InputTag>("tracks"))),
       convertedTracksToken_(
           consumes<edm::View<Track_t>>(iConfig.getUntrackedParameter<edm::InputTag>("convertedTracks"))),
@@ -143,14 +143,14 @@ GTTInputFileWriter::GTTInputFileWriter(const edm::ParameterSet& iConfig)
   //now do what ever initialization is needed
 }
 
-GTTInputFileWriter::~GTTInputFileWriter() {
+GTTFileWriter::~GTTFileWriter() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
   //
   // please remove this method altogether if it would be left empty
 }
 
-void GTTInputFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void GTTFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
   // Select links for correct time slice (18 input links per time slice)
@@ -188,12 +188,12 @@ void GTTInputFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void GTTInputFileWriter::beginJob() {
+void GTTFileWriter::beginJob() {
   // please remove this method if not needed
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void GTTInputFileWriter::endJob() {
+void GTTFileWriter::endJob() {
   // Writing pending events to file before exiting
   fileWriterInputTracks_.flush();
   fileWriterConvertedTracks_.flush();
@@ -201,7 +201,7 @@ void GTTInputFileWriter::endJob() {
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void GTTInputFileWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void GTTFileWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
@@ -216,4 +216,4 @@ void GTTInputFileWriter::fillDescriptions(edm::ConfigurationDescriptions& descri
 }
 
 //define this as a plug-in
-DEFINE_FWK_MODULE(GTTInputFileWriter);
+DEFINE_FWK_MODULE(GTTFileWriter);

--- a/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
@@ -55,12 +55,52 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
+  // ----------constants, enums and typedefs ---------
+  // NOTE: At least some of the info from these constants will eventually come from config files
+  static constexpr size_t kFramesPerTMUXPeriod = 9;
+  static constexpr size_t kGapLength = 6;
+  static constexpr size_t kTrackTMUX = 18;
+  static constexpr size_t kGTTBoardTMUX = 6;
+  static constexpr size_t kMaxLinesPerFile = 1024;
+
+  const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecsInput = {
+      /* channel index -> {link TMUX, TMUX index, inter-packet gap} */
+      {0, {kTrackTMUX, 0, kGapLength}},   {1, {kTrackTMUX, 0, kGapLength}},   {2, {kTrackTMUX, 0, kGapLength}},
+      {3, {kTrackTMUX, 0, kGapLength}},   {4, {kTrackTMUX, 0, kGapLength}},   {5, {kTrackTMUX, 0, kGapLength}},
+      {6, {kTrackTMUX, 0, kGapLength}},   {7, {kTrackTMUX, 0, kGapLength}},   {8, {kTrackTMUX, 0, kGapLength}},
+
+      {9, {kTrackTMUX, 0, kGapLength}},   {10, {kTrackTMUX, 0, kGapLength}},  {11, {kTrackTMUX, 0, kGapLength}},
+      {12, {kTrackTMUX, 0, kGapLength}},  {13, {kTrackTMUX, 0, kGapLength}},  {14, {kTrackTMUX, 0, kGapLength}},
+      {15, {kTrackTMUX, 0, kGapLength}},  {16, {kTrackTMUX, 0, kGapLength}},  {17, {kTrackTMUX, 0, kGapLength}},
+
+      {18, {kTrackTMUX, 6, kGapLength}},  {19, {kTrackTMUX, 6, kGapLength}},  {20, {kTrackTMUX, 6, kGapLength}},
+      {21, {kTrackTMUX, 6, kGapLength}},  {22, {kTrackTMUX, 6, kGapLength}},  {23, {kTrackTMUX, 6, kGapLength}},
+      {24, {kTrackTMUX, 6, kGapLength}},  {25, {kTrackTMUX, 6, kGapLength}},  {26, {kTrackTMUX, 6, kGapLength}},
+
+      {27, {kTrackTMUX, 6, kGapLength}},  {28, {kTrackTMUX, 6, kGapLength}},  {29, {kTrackTMUX, 6, kGapLength}},
+      {30, {kTrackTMUX, 6, kGapLength}},  {31, {kTrackTMUX, 6, kGapLength}},  {32, {kTrackTMUX, 6, kGapLength}},
+      {33, {kTrackTMUX, 6, kGapLength}},  {34, {kTrackTMUX, 6, kGapLength}},  {35, {kTrackTMUX, 6, kGapLength}},
+
+      {36, {kTrackTMUX, 12, kGapLength}}, {37, {kTrackTMUX, 12, kGapLength}}, {38, {kTrackTMUX, 12, kGapLength}},
+      {39, {kTrackTMUX, 12, kGapLength}}, {40, {kTrackTMUX, 12, kGapLength}}, {41, {kTrackTMUX, 12, kGapLength}},
+      {42, {kTrackTMUX, 12, kGapLength}}, {43, {kTrackTMUX, 12, kGapLength}}, {44, {kTrackTMUX, 12, kGapLength}},
+
+      {45, {kTrackTMUX, 12, kGapLength}}, {46, {kTrackTMUX, 12, kGapLength}}, {47, {kTrackTMUX, 12, kGapLength}},
+      {48, {kTrackTMUX, 12, kGapLength}}, {49, {kTrackTMUX, 12, kGapLength}}, {50, {kTrackTMUX, 12, kGapLength}},
+      {51, {kTrackTMUX, 12, kGapLength}}, {52, {kTrackTMUX, 12, kGapLength}}, {53, {kTrackTMUX, 12, kGapLength}}};
+
+  const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecsOutputToCorrelator = {
+      /* channel index -> {link TMUX, TMUX index, inter-packet gap} */
+      {0, {kGTTBoardTMUX, 0, kGapLength}}};
+
   typedef TTTrack<Ref_Phase2TrackerDigi_> Track_t;
 
+  // ----------member functions ----------------------
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
 
+  // ----------member data ---------------------------
   edm::EDGetTokenT<edm::View<Track_t>> tracksToken_;
   edm::EDGetTokenT<edm::View<Track_t>> convertedTracksToken_;
   edm::EDGetTokenT<edm::View<l1t::VertexWord>> verticesToken_;
@@ -69,48 +109,6 @@ private:
   l1t::demo::BoardDataWriter fileWriterConvertedTracks_;
   l1t::demo::BoardDataWriter fileWriterOutputToCorrelator_;
 };
-
-//
-// constants, enums and typedefs
-//
-
-// NOTE: At least some of the info from these constants will eventually come from config files
-constexpr size_t kGapLength(6);
-constexpr size_t kTrackTMUX(18);
-
-const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecsInput = {
-    /* channel index -> {link TMUX, TMUX index, inter-packet gap} */
-    {0, {kTrackTMUX, 0, kGapLength}},   {1, {kTrackTMUX, 0, kGapLength}},   {2, {kTrackTMUX, 0, kGapLength}},
-    {3, {kTrackTMUX, 0, kGapLength}},   {4, {kTrackTMUX, 0, kGapLength}},   {5, {kTrackTMUX, 0, kGapLength}},
-    {6, {kTrackTMUX, 0, kGapLength}},   {7, {kTrackTMUX, 0, kGapLength}},   {8, {kTrackTMUX, 0, kGapLength}},
-
-    {9, {kTrackTMUX, 0, kGapLength}},   {10, {kTrackTMUX, 0, kGapLength}},  {11, {kTrackTMUX, 0, kGapLength}},
-    {12, {kTrackTMUX, 0, kGapLength}},  {13, {kTrackTMUX, 0, kGapLength}},  {14, {kTrackTMUX, 0, kGapLength}},
-    {15, {kTrackTMUX, 0, kGapLength}},  {16, {kTrackTMUX, 0, kGapLength}},  {17, {kTrackTMUX, 0, kGapLength}},
-
-    {18, {kTrackTMUX, 6, kGapLength}},  {19, {kTrackTMUX, 6, kGapLength}},  {20, {kTrackTMUX, 6, kGapLength}},
-    {21, {kTrackTMUX, 6, kGapLength}},  {22, {kTrackTMUX, 6, kGapLength}},  {23, {kTrackTMUX, 6, kGapLength}},
-    {24, {kTrackTMUX, 6, kGapLength}},  {25, {kTrackTMUX, 6, kGapLength}},  {26, {kTrackTMUX, 6, kGapLength}},
-
-    {27, {kTrackTMUX, 6, kGapLength}},  {28, {kTrackTMUX, 6, kGapLength}},  {29, {kTrackTMUX, 6, kGapLength}},
-    {30, {kTrackTMUX, 6, kGapLength}},  {31, {kTrackTMUX, 6, kGapLength}},  {32, {kTrackTMUX, 6, kGapLength}},
-    {33, {kTrackTMUX, 6, kGapLength}},  {34, {kTrackTMUX, 6, kGapLength}},  {35, {kTrackTMUX, 6, kGapLength}},
-
-    {36, {kTrackTMUX, 12, kGapLength}}, {37, {kTrackTMUX, 12, kGapLength}}, {38, {kTrackTMUX, 12, kGapLength}},
-    {39, {kTrackTMUX, 12, kGapLength}}, {40, {kTrackTMUX, 12, kGapLength}}, {41, {kTrackTMUX, 12, kGapLength}},
-    {42, {kTrackTMUX, 12, kGapLength}}, {43, {kTrackTMUX, 12, kGapLength}}, {44, {kTrackTMUX, 12, kGapLength}},
-
-    {45, {kTrackTMUX, 12, kGapLength}}, {46, {kTrackTMUX, 12, kGapLength}}, {47, {kTrackTMUX, 12, kGapLength}},
-    {48, {kTrackTMUX, 12, kGapLength}}, {49, {kTrackTMUX, 12, kGapLength}}, {50, {kTrackTMUX, 12, kGapLength}},
-    {51, {kTrackTMUX, 12, kGapLength}}, {52, {kTrackTMUX, 12, kGapLength}}, {53, {kTrackTMUX, 12, kGapLength}}};
-
-const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecsOutputToCorrelator = {
-    /* channel index -> {link TMUX, TMUX index, inter-packet gap} */
-    {0, {kTrackTMUX, 0, kGapLength}}};
-
-//
-// static data member definitions
-//
 
 //
 // constructors and destructor
@@ -124,21 +122,21 @@ GTTFileWriter::GTTFileWriter(const edm::ParameterSet& iConfig)
       eventCount_(0),
       fileWriterInputTracks_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
                              iConfig.getUntrackedParameter<std::string>("inputFilename"),
-                             9,
-                             6,
-                             1024,
+                             kFramesPerTMUXPeriod,
+                             kGTTBoardTMUX,
+                             kMaxLinesPerFile,
                              kChannelSpecsInput),
       fileWriterConvertedTracks_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
                                  iConfig.getUntrackedParameter<std::string>("inputConvertedFilename"),
-                                 9,
-                                 6,
-                                 1024,
+                                 kFramesPerTMUXPeriod,
+                                 kGTTBoardTMUX,
+                                 kMaxLinesPerFile,
                                  kChannelSpecsInput),
       fileWriterOutputToCorrelator_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
                                     iConfig.getUntrackedParameter<std::string>("outputFilename"),
-                                    9,
-                                    6,
-                                    1024,
+                                    kFramesPerTMUXPeriod,
+                                    kGTTBoardTMUX,
+                                    kMaxLinesPerFile,
                                     kChannelSpecsOutputToCorrelator) {
   //now do what ever initialization is needed
 }

--- a/L1Trigger/DemonstratorTools/plugins/GTTInputFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTInputFileWriter.cc
@@ -67,7 +67,7 @@ private:
   size_t eventCount_;
   l1t::demo::BoardDataWriter fileWriterInputTracks_;
   l1t::demo::BoardDataWriter fileWriterConvertedTracks_;
-  l1t::demo::BoardDataWriter fileWriterOutput_;
+  l1t::demo::BoardDataWriter fileWriterOutputToCorrelator_;
 };
 
 //
@@ -104,7 +104,7 @@ const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecsInput = {
     {48, {kTrackTMUX, 12, kGapLength}}, {49, {kTrackTMUX, 12, kGapLength}}, {50, {kTrackTMUX, 12, kGapLength}},
     {51, {kTrackTMUX, 12, kGapLength}}, {52, {kTrackTMUX, 12, kGapLength}}, {53, {kTrackTMUX, 12, kGapLength}}};
 
-const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecsOutput = {
+const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecsOutputToCorrelator = {
     /* channel index -> {link TMUX, TMUX index, inter-packet gap} */
     {0, {kTrackTMUX, 0, kGapLength}}};
 
@@ -133,12 +133,12 @@ GTTInputFileWriter::GTTInputFileWriter(const edm::ParameterSet& iConfig)
                                  6,
                                  1024,
                                  kChannelSpecsInput),
-      fileWriterOutput_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
+      fileWriterOutputToCorrelator_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
                         iConfig.getUntrackedParameter<std::string>("outputFilename"),
                         9,
                         6,
                         1024,
-                        kChannelSpecsOutput) {
+                        kChannelSpecsOutputToCorrelator) {
   //now do what ever initialization is needed
 }
 
@@ -183,7 +183,7 @@ void GTTInputFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   fileWriterInputTracks_.addEvent(boardDataTracks);
   fileWriterConvertedTracks_.addEvent(boardDataConvertedTracks);
-  fileWriterOutput_.addEvent(boardDataVertices);
+  fileWriterOutputToCorrelator_.addEvent(boardDataVertices);
 }
 
 // ------------ method called once each job just before starting event loop  ------------
@@ -194,7 +194,9 @@ void GTTInputFileWriter::beginJob() {
 // ------------ method called once each job just after ending the event loop  ------------
 void GTTInputFileWriter::endJob() {
   // Writing pending events to file before exiting
-  fileWriter_.flush();
+  fileWriterInputTracks_.flush();
+  fileWriterConvertedTracks_.flush();
+  fileWriterOutputToCorrelator_.flush();
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/L1Trigger/DemonstratorTools/plugins/GTTInputFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTInputFileWriter.cc
@@ -118,7 +118,8 @@ const std::map<size_t, l1t::demo::ChannelSpec> kChannelSpecsOutputToCorrelator =
 
 GTTInputFileWriter::GTTInputFileWriter(const edm::ParameterSet& iConfig)
     : tracksToken_(consumes<edm::View<Track_t>>(iConfig.getUntrackedParameter<edm::InputTag>("tracks"))),
-      convertedTracksToken_(consumes<edm::View<Track_t>>(iConfig.getUntrackedParameter<edm::InputTag>("convertedTracks"))),
+      convertedTracksToken_(
+          consumes<edm::View<Track_t>>(iConfig.getUntrackedParameter<edm::InputTag>("convertedTracks"))),
       verticesToken_(consumes<edm::View<l1t::VertexWord>>(iConfig.getUntrackedParameter<edm::InputTag>("vertices"))),
       eventCount_(0),
       fileWriterInputTracks_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
@@ -134,11 +135,11 @@ GTTInputFileWriter::GTTInputFileWriter(const edm::ParameterSet& iConfig)
                                  1024,
                                  kChannelSpecsInput),
       fileWriterOutputToCorrelator_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
-                        iConfig.getUntrackedParameter<std::string>("outputFilename"),
-                        9,
-                        6,
-                        1024,
-                        kChannelSpecsOutputToCorrelator) {
+                                    iConfig.getUntrackedParameter<std::string>("outputFilename"),
+                                    9,
+                                    6,
+                                    1024,
+                                    kChannelSpecsOutputToCorrelator) {
   //now do what ever initialization is needed
 }
 

--- a/L1Trigger/DemonstratorTools/python/GTTFileReader_cff.py
+++ b/L1Trigger/DemonstratorTools/python/GTTFileReader_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-GTTOutputFileReader = cms.EDProducer('GTTOutputFileReader',
+GTTFileReader = cms.EDProducer('GTTOutputFileReader',
   files = cms.vstring("gttOutput_0.txt"), #, "gttOutput_1.txt"),
   format = cms.untracked.string("APx")
 )

--- a/L1Trigger/DemonstratorTools/python/GTTFileWriter_cff.py
+++ b/L1Trigger/DemonstratorTools/python/GTTFileWriter_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-GTTInputFileWriter = cms.EDAnalyzer('GTTInputFileWriter',
+GTTFileWriter = cms.EDAnalyzer('GTTFileWriter',
   tracks = cms.untracked.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
   convertedTracks = cms.untracked.InputTag("L1GTTInputProducer","Level1TTTracksConverted"),
   vertices = cms.untracked.InputTag("VertexProducer", "l1verticesEmulation"),

--- a/L1Trigger/DemonstratorTools/python/GTTInputFileWriter_cff.py
+++ b/L1Trigger/DemonstratorTools/python/GTTInputFileWriter_cff.py
@@ -6,6 +6,6 @@ GTTInputFileWriter = cms.EDAnalyzer('GTTInputFileWriter',
   vertices = cms.untracked.InputTag("VertexProducer", "l1verticesEmulation"),
   inputFilename = cms.untracked.string("L1GTTInputFile"),
   inputConvertedFilename = cms.untracked.string("L1GTTInputConvertedFile"),
-  outputFilename = cms.untracked.string("L1GTTOutputFile"),
+  outputFilename = cms.untracked.string("L1GTTOutputToCorrelatorFile"),
   format = cms.untracked.string("APx")
 )

--- a/L1Trigger/DemonstratorTools/python/GTTInputFileWriter_cff.py
+++ b/L1Trigger/DemonstratorTools/python/GTTInputFileWriter_cff.py
@@ -2,6 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 GTTInputFileWriter = cms.EDAnalyzer('GTTInputFileWriter',
   tracks = cms.untracked.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
-  outputFilename = cms.untracked.string("gttInputFile"),
+  convertedTracks = cms.untracked.InputTag("L1GTTInputProducer","Level1TTTracksConverted"),
+  vertices = cms.untracked.InputTag("VertexProducer", "l1verticesEmulation"),
+  inputFilename = cms.untracked.string("L1GTTInputFile"),
+  inputConvertedFilename = cms.untracked.string("L1GTTInputConvertedFile"),
+  outputFilename = cms.untracked.string("L1GTTOutputFile"),
   format = cms.untracked.string("APx")
 )

--- a/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
@@ -3,9 +3,7 @@
 
 namespace l1t::demo::codecs {
 
-  ap_uint<96> encodeTrack(const TTTrack_TrackWord& t) {
-    return t.getTrackWord();
-  }
+  ap_uint<96> encodeTrack(const TTTrack_TrackWord& t) { return t.getTrackWord(); }
 
   // Encodes track collection onto 18 output links (2x9 eta-phi sectors; first 9 negative eta)
   std::array<l1t::demo::BoardData::Channel, 18> encodeTracks(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks) {

--- a/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
@@ -4,24 +4,7 @@
 namespace l1t::demo::codecs {
 
   ap_uint<96> encodeTrack(const TTTrack_TrackWord& t) {
-    // FIXME: Update to actually encode track parameters (just hardcoding values
-    //        right now to verify file-writing and packing of 96-bit words).
-
-    ap_uint<96> word(0);
-    word.set(0);   // valid
-    word.set(1);   // pt
-    word.set(16);  // phi
-    word.set(28);  // tanLambda
-    word.set(44);  // z0
-    word.set(56);  // d0
-    word.set(69);  // chi2 (r-phi)
-    word.set(73);  // chi2 (r-z)
-    word.set(77);  // bend chi2
-    word.set(80);  // hit pattern
-    word.set(87);  // MVA track quality
-    word.set(90);  // Other MVAs
-
-    return word;
+    return t.getTrackWord();
   }
 
   // Encodes track collection onto 18 output links (2x9 eta-phi sectors; first 9 negative eta)

--- a/L1Trigger/DemonstratorTools/src/codecs_vertices.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_vertices.cc
@@ -17,7 +17,8 @@ namespace l1t::demo::codecs {
     std::array<l1t::demo::BoardData::Channel, 1> linkData;
 
     for (size_t i = 0; i < linkData.size(); i++) {
-      // No need to pad the vertices with valid, but {0} frames
+      // Pad vertex vectors -> full packet length (10 frames = 10 vertices)
+      vertexWords.resize(10, 0);
       linkData.at(i).resize(vertexWords.size(), {0});
 
       for (size_t j = 0; (j < vertexWords.size()); j++) {

--- a/L1Trigger/DemonstratorTools/src/codecs_vertices.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_vertices.cc
@@ -3,9 +3,7 @@
 
 namespace l1t::demo::codecs {
 
-  ap_uint<64> encodeVertex(const l1t::VertexWord& v) {
-    return v.vertexWord();
-  }
+  ap_uint<64> encodeVertex(const l1t::VertexWord& v) { return v.vertexWord(); }
 
   // Encodes vertex collection onto 1 output link
   std::array<l1t::demo::BoardData::Channel, 1> encodeVertices(const edm::View<l1t::VertexWord>& vertices) {

--- a/L1Trigger/DemonstratorTools/src/codecs_vertices.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_vertices.cc
@@ -3,6 +3,31 @@
 
 namespace l1t::demo::codecs {
 
+  ap_uint<64> encodeVertex(const l1t::VertexWord& v) {
+    return v.vertexWord();
+  }
+
+  // Encodes vertex collection onto 1 output link
+  std::array<l1t::demo::BoardData::Channel, 1> encodeVertices(const edm::View<l1t::VertexWord>& vertices) {
+    std::vector<ap_uint<64>> vertexWords;
+
+    for (const auto& vertex : vertices)
+      vertexWords.push_back(encodeVertex(vertex));
+
+    std::array<l1t::demo::BoardData::Channel, 1> linkData;
+
+    for (size_t i = 0; i < linkData.size(); i++) {
+      // No need to pad the vertices with valid, but {0} frames
+      linkData.at(i).resize(vertexWords.size(), {0});
+
+      for (size_t j = 0; (j < vertexWords.size()); j++) {
+        linkData.at(i).at(j).data = vertexWords.at(j)(63, 0);
+      }
+    }
+
+    return linkData;
+  }
+
   std::vector<l1t::VertexWord> decodeVertices(const l1t::demo::BoardData::Channel& frames) {
     std::vector<l1t::VertexWord> vertices;
 

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -23,7 +23,7 @@ for filePath in options.inputFiles:
 
 # PART 2: SETUP MAIN CMSSW PROCESS 
 
-process = cms.Process("GTTInputWriter")
+process = cms.Process("GTTFileWriter")
 
 process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
 process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
@@ -39,15 +39,15 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxE
 process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
 process.load('L1Trigger.L1TTrackMatch.L1GTTInputProducer_cfi')
 process.load('L1Trigger.VertexFinder.VertexProducer_cff')
-process.load('L1Trigger.DemonstratorTools.GTTInputFileWriter_cff')
+process.load('L1Trigger.DemonstratorTools.GTTFileWriter_cff')
 
 process.VertexProducer.l1TracksInputTag = cms.InputTag("L1GTTInputProducer","Level1TTTracksConverted")
 process.VertexProducer.VertexReconstruction.Algorithm = cms.string("FastHistoEmulation")
 
-process.GTTInputFileWriter.format = cms.untracked.string(options.format)
-# process.GTTInputFileWriter.outputFilename = cms.untracked.string("myOutputFile.txt")
+process.GTTFileWriter.format = cms.untracked.string(options.format)
+# process.GTTFileWriter.outputFilename = cms.untracked.string("myOutputFile.txt")
 
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 process.Timing = cms.Service("Timing", summaryOnly = cms.untracked.bool(True))
 
-process.p = cms.Path(process.L1HybridTracks * process.L1GTTInputProducer * process.VertexProducer * process.GTTInputFileWriter)
+process.p = cms.Path(process.L1HybridTracks * process.L1GTTInputProducer * process.VertexProducer * process.GTTFileWriter)

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -1,4 +1,3 @@
-
 import FWCore.ParameterSet.Config as cms
 import FWCore.Utilities.FileUtils as FileUtils
 import FWCore.ParameterSet.VarParsing as VarParsing
@@ -38,7 +37,16 @@ process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(inpu
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
 
 process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
+process.load('L1Trigger.L1TTrackMatch.L1GTTInputProducer_cfi')
+#process.load("L1Trigger.L1TTrackMatch.L1TrackJetProducer_cfi")
+#process.load("L1Trigger.L1TTrackMatch.L1TrackFastJetProducer_cfi")
+#process.load("L1Trigger.L1TTrackMatch.L1TrackerEtMissProducer_cfi")
+#process.load("L1Trigger.L1TTrackMatch.L1TkHTMissProducer_cfi")
+process.load('L1Trigger.VertexFinder.VertexProducer_cff')
 process.load('L1Trigger.DemonstratorTools.GTTInputFileWriter_cff')
+
+process.VertexProducer.l1TracksInputTag = cms.InputTag("L1GTTInputProducer","Level1TTTracksConverted")
+process.VertexProducer.VertexReconstruction.Algorithm = cms.string("FastHistoEmulation")
 
 process.GTTInputFileWriter.format = cms.untracked.string(options.format)
 # process.GTTInputFileWriter.outputFilename = cms.untracked.string("myOutputFile.txt")
@@ -46,4 +54,4 @@ process.GTTInputFileWriter.format = cms.untracked.string(options.format)
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 process.Timing = cms.Service("Timing", summaryOnly = cms.untracked.bool(True))
 
-process.p = cms.Path(process.L1HybridTracks * process.GTTInputFileWriter)
+process.p = cms.Path(process.L1HybridTracks * process.L1GTTInputProducer * process.VertexProducer * process.GTTInputFileWriter)

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -38,10 +38,6 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxE
 
 process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
 process.load('L1Trigger.L1TTrackMatch.L1GTTInputProducer_cfi')
-#process.load("L1Trigger.L1TTrackMatch.L1TrackJetProducer_cfi")
-#process.load("L1Trigger.L1TTrackMatch.L1TrackFastJetProducer_cfi")
-#process.load("L1Trigger.L1TTrackMatch.L1TrackerEtMissProducer_cfi")
-#process.load("L1Trigger.L1TTrackMatch.L1TkHTMissProducer_cfi")
 process.load('L1Trigger.VertexFinder.VertexProducer_cff')
 process.load('L1Trigger.DemonstratorTools.GTTInputFileWriter_cff')
 

--- a/L1Trigger/DemonstratorTools/test/gtt/verifyFirmwareOutput_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/verifyFirmwareOutput_cfg.py
@@ -24,7 +24,7 @@ for filePath in options.inputFiles:
 
 # PART 2: SETUP MAIN CMSSW PROCESS 
 
-process = cms.Process("GTTOutputValidation")
+process = cms.Process("GTTValidation")
 
 process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
 process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
@@ -38,11 +38,11 @@ process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(inpu
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
 
 process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
-process.load('L1Trigger.DemonstratorTools.GTTOutputFileReader_cff')
-process.GTTOutputFileReader.files = cms.vstring("test/gtt/example_vertex_apx.txt")
-process.GTTOutputFileReader.format = cms.untracked.string(options.format)
+process.load('L1Trigger.DemonstratorTools.GTTFileReader_cff')
+process.GTTFileReader.files = cms.vstring("test/gtt/example_vertex_apx.txt")
+process.GTTFileReader.format = cms.untracked.string(options.format)
 
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 process.Timing = cms.Service("Timing", summaryOnly = cms.untracked.bool(True))
 
-process.p = cms.Path(process.L1HybridTracks * process.GTTOutputFileReader) # vertex emulator & FW-emulator comparsion module need to be added here
+process.p = cms.Path(process.L1HybridTracks * process.GTTFileReader) # vertex emulator & FW-emulator comparsion module need to be added here


### PR DESCRIPTION
#### PR description:

This PR adds to the functionality of the text file writing code. Instead of just outputting a single file for the TTTracks from emulation, it now outputs two more; one for the tracks with converted 1/R->pt and tanL->eta and one for the output vertices.

It also renames the GTTInputFileWriter->GTTFileWriter and GTTOutputFileReader->GTTFileReader to more closely match their functionality. They will both, eventually, read or write both inputs and outputs.

#### PR validation:

This PR was validated in the following ways:
1. `scram b code-checks`
2. `scram b code-format`
3. I ran the code to see that the converted track bit patterns matched the expected patterns given by the original tracks.